### PR TITLE
fix: cache 502/504/429 responses to prevent rate-limit cascade

### DIFF
--- a/homecom_alt/__init__.py
+++ b/homecom_alt/__init__.py
@@ -185,6 +185,7 @@ from .model import (
 _LOGGER = logging.getLogger(__name__)
 
 _NOT_FOUND_CACHE_TTL: float = 86400.0  # 24 hours
+_TRANSIENT_ERROR_CACHE_TTL: float = 300.0  # 5 minutes — for 429/502/504
 
 
 class HomeComAlt:
@@ -205,6 +206,7 @@ class HomeComAlt:
         self._oauth_refresh_params = OAUTH_REFRESH_PARAMS
         self._lock = asyncio.Lock()
         self._not_found_cache: dict[str, float] = {}
+        self._transient_error_cache: dict[str, float] = {}
 
     @property
     def refresh_token(self) -> str | None:
@@ -246,6 +248,17 @@ class HomeComAlt:
                 _LOGGER.debug("Skipping cached 404 endpoint %s", url)
                 return {}
             del self._not_found_cache[url]
+
+        if method.upper() == "GET" and url in self._transient_error_cache:
+            if (
+                time.monotonic() - self._transient_error_cache[url]
+                < _TRANSIENT_ERROR_CACHE_TTL
+            ):
+                _LOGGER.debug(
+                    "Skipping endpoint %s (cached transient error)", url
+                )
+                return {}
+            del self._transient_error_cache[url]
 
         headers = {
             "Authorization": f"Bearer {self._options.token}"  # Set Bearer token
@@ -289,9 +302,19 @@ class HomeComAlt:
                 HTTPStatus.GATEWAY_TIMEOUT.value,  # 504
             ):
                 _LOGGER.warning("Endpoint %s returned %s", url, error.status)
+                if method.upper() == "GET":
+                    self._transient_error_cache[url] = time.monotonic()
                 return {}
             if error.status == HTTPStatus.TOO_MANY_REQUESTS.value:
-                _LOGGER.warning("Endpoint %s returned %s", url, error.status)
+                _LOGGER.warning(
+                    "Endpoint %s returned %s — caching for %ss",
+                    url,
+                    error.status,
+                    _TRANSIENT_ERROR_CACHE_TTL,
+                )
+                if method.upper() == "GET":
+                    self._transient_error_cache[url] = time.monotonic()
+                    return {}
                 raise NotRespondingError(f"{url} is rate limited") from error
             raise ApiError(
                 f"Invalid response from url {url}: {error.status}"


### PR DESCRIPTION
## Summary

Cache **502 / 504 / 429** responses (5-minute TTL) to prevent endpoint thrashing that escalates into gateway-wide rate limiting on iCom devices.

## Problem

`_async_http_request` already caches **404** responses for 24 hours via `_not_found_cache`. However, on iCom heat pumps (e.g. IVT AX90), the Bosch Pointt API returns **504 Gateway Timeout** for unsupported endpoints (`/resource/ventilation`, `/resource/zones`, `/resource/heatSources/flameIndication`, `/resource/system/powerLimitation/active`, …) instead of 404.

Because 504 was returning `{}` without caching, the integration kept re-querying these endpoints every cycle. With ~50 endpoints fired in parallel via `asyncio.gather()`, Bosch escalates to **429 Too Many Requests** at the gateway level, breaking both this integration and the official Bosch HomeCom Easy mobile app.

## Change

- New constant `_TRANSIENT_ERROR_CACHE_TTL = 300.0` (5 min)
- New instance dict `self._transient_error_cache`
- `_async_http_request` now skips GETs that have a recent transient-error entry
- 502 / 504 GETs populate the cache (no API call for 5 min)
- 429 GETs populate the cache and return `{}` instead of raising — a single rate-limited endpoint no longer fails the whole update cycle. POST/PUT/DELETE on 429 still raise `NotRespondingError`.

## Impact (expected)

- After the first update cycle, unsupported / temporarily-failing endpoints should be skipped client-side.
- Total request volume per cycle should drop from ~50 to ~10 supported endpoints once the cache warms up.
- 404 cache behavior is unchanged.

## Status

⚠️ **Not yet runtime-tested** — the patch was written from log analysis on the affected device (IVT AX90 + iCom commodule, gateway 619350951) but I have not yet installed the fork in HA. Happy to test if you'd like specific verification before merging, or treat this as a starting point for review.

## Reference

Reported as a regression of [serbanb11/bosch-homecom-hass#110](https://github.com/serbanb11/bosch-homecom-hass/issues/110) in [serbanb11/bosch-homecom-hass#120](https://github.com/serbanb11/bosch-homecom-hass/issues/120).

Pairs with serbanb11/bosch-homecom-hass#121 (defensive `None` handling in `sensor.py:841`).