### PR TITLE
feat(k40): bulk per-HC and per-ventilation endpoints

### DIFF
--- a/homecom_alt/k40.py
+++ b/homecom_alt/k40.py
@@ -2132,50 +2132,69 @@ class HomeComK40(HomeComAlt):
 
             async def populate_hc(ref: dict[str, Any]) -> None:
                 hc_id = ref["id"].split("/")[-1]
-                (
-                    ref["operationMode"],
-                    ref["currentSuWiMode"],
-                    ref["heatCoolMode"],
-                    ref["roomTemp"],
-                    ref["actualHumidity"],
-                    ref["manualRoomSetpoint"],
-                    ref["currentRoomSetpoint"],
-                    ref["coolingRoomTempSetpoint"],
-                    ref["maxSupply"],
-                    ref["minSupply"],
-                    ref["heatCurveMax"],
-                    ref["heatCurveMin"],
-                    ref["supplyTemperatureSetpoint"],
-                    ref["nightSwitchMode"],
-                    ref["control"],
-                    ref["nightThreshold"],
-                    ref["roomInfluence"],
-                ) = await asyncio.gather(
-                    limited_call(self.async_get_hc_operation_mode(device_id, hc_id)),
-                    limited_call(self.async_get_hc_suwi_mode(device_id, hc_id)),
-                    limited_call(self.async_get_hc_heatcool_mode(device_id, hc_id)),
-                    limited_call(self.async_get_hc_room_temp(device_id, hc_id)),
-                    limited_call(self.async_get_hc_actual_humidity(device_id, hc_id)),
-                    limited_call(
-                        self.async_get_hc_manual_room_setpoint(device_id, hc_id)
-                    ),
-                    limited_call(
-                        self.async_get_hc_current_room_setpoint(device_id, hc_id)
-                    ),
-                    limited_call(
-                        self.async_get_hc_cooling_room_temp_setpoint(device_id, hc_id)
-                    ),
-                    limited_call(self.async_get_hc_max_supply(device_id, hc_id)),
-                    limited_call(self.async_get_hc_min_supply(device_id, hc_id)),
-                    limited_call(self.async_get_hc_heat_curve_max(device_id, hc_id)),
-                    limited_call(self.async_get_hc_heat_curve_min(device_id, hc_id)),
-                    limited_call(
-                        self.async_get_hc_supply_temp_setpoint(device_id, hc_id)
-                    ),
-                    limited_call(self.async_get_hc_night_switch_mode(device_id, hc_id)),
-                    limited_call(self.async_get_hc_control(device_id, hc_id)),
-                    limited_call(self.async_get_hc_night_threshold(device_id, hc_id)),
-                    limited_call(self.async_get_hc_room_influence(device_id, hc_id)),
+                prefix = BOSCHCOM_ENDPOINT_HEATING_CIRCUITS + "/" + hc_id
+                hc_endpoints = [
+                    prefix + BOSCHCOM_ENDPOINT_HC_OPERATION_MODE,
+                    prefix + BOSCHCOM_ENDPOINT_HC_SUWI_MODE,
+                    prefix + BOSCHCOM_ENDPOINT_HC_HEATCOOL_MODE,
+                    prefix + BOSCHCOM_ENDPOINT_HC_ROOM_TEMP,
+                    prefix + BOSCHCOM_ENDPOINT_HC_ACTUAL_HUMIDITY,
+                    prefix + BOSCHCOM_ENDPOINT_HC_MANUAL_ROOM_SETPOINT,
+                    prefix + BOSCHCOM_ENDPOINT_HC_CURRENT_ROOM_SETPOINT,
+                    prefix + BOSCHCOM_ENDPOINT_HC_COOLING_ROOM_TEMP_SETPOINT,
+                    prefix + BOSCHCOM_ENDPOINT_HC_MAX_SUPPLY,
+                    prefix + BOSCHCOM_ENDPOINT_HC_MIN_SUPPLY,
+                    prefix + BOSCHCOM_ENDPOINT_HC_HEAT_CURVE_MAX,
+                    prefix + BOSCHCOM_ENDPOINT_HC_HEAT_CURVE_MIN,
+                    prefix + BOSCHCOM_ENDPOINT_HC_SUPPLY_TEMP_SETPOINT,
+                    prefix + BOSCHCOM_ENDPOINT_HC_NIGHT_SWITCH_MODE,
+                    prefix + BOSCHCOM_ENDPOINT_HC_CONTROL,
+                    prefix + BOSCHCOM_ENDPOINT_HC_NIGHT_THRESHOLD,
+                    prefix + BOSCHCOM_ENDPOINT_HC_ROOM_INFLUENCE,
+                ]
+                hc_bulk = await self.async_request_bulk(device_id, hc_endpoints) or {}
+                ref["operationMode"] = hc_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_HC_OPERATION_MODE
+                )
+                ref["currentSuWiMode"] = hc_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_HC_SUWI_MODE
+                )
+                ref["heatCoolMode"] = hc_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_HC_HEATCOOL_MODE
+                )
+                ref["roomTemp"] = hc_bulk.get(prefix + BOSCHCOM_ENDPOINT_HC_ROOM_TEMP)
+                ref["actualHumidity"] = hc_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_HC_ACTUAL_HUMIDITY
+                )
+                ref["manualRoomSetpoint"] = hc_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_HC_MANUAL_ROOM_SETPOINT
+                )
+                ref["currentRoomSetpoint"] = hc_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_HC_CURRENT_ROOM_SETPOINT
+                )
+                ref["coolingRoomTempSetpoint"] = hc_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_HC_COOLING_ROOM_TEMP_SETPOINT
+                )
+                ref["maxSupply"] = hc_bulk.get(prefix + BOSCHCOM_ENDPOINT_HC_MAX_SUPPLY)
+                ref["minSupply"] = hc_bulk.get(prefix + BOSCHCOM_ENDPOINT_HC_MIN_SUPPLY)
+                ref["heatCurveMax"] = hc_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_HC_HEAT_CURVE_MAX
+                )
+                ref["heatCurveMin"] = hc_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_HC_HEAT_CURVE_MIN
+                )
+                ref["supplyTemperatureSetpoint"] = hc_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_HC_SUPPLY_TEMP_SETPOINT
+                )
+                ref["nightSwitchMode"] = hc_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_HC_NIGHT_SWITCH_MODE
+                )
+                ref["control"] = hc_bulk.get(prefix + BOSCHCOM_ENDPOINT_HC_CONTROL)
+                ref["nightThreshold"] = hc_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_HC_NIGHT_THRESHOLD
+                )
+                ref["roomInfluence"] = hc_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_HC_ROOM_INFLUENCE
                 )
 
                 (
@@ -2209,76 +2228,79 @@ class HomeComK40(HomeComAlt):
 
             async def populate_vent(ref: dict[str, Any]) -> None:
                 zone_id = ref["id"].split("/")[-1]
-                (
-                    ref["exhaustFanLevel"],
-                    ref["maxIndoorAirQuality"],
-                    ref["maxRelativeHumidity"],
-                    ref["operationMode"],
-                    ref["exhaustTemp"],
-                    ref["extractTemp"],
-                    ref["internalAirQuality"],
-                    ref["internalHumidity"],
-                    ref["outdoorTemp"],
-                    ref["supplyTemp"],
-                    ref["summerBypassEnable"],
-                    ref["summerBypassDuration"],
-                    ref["summerBypassFlapPower"],
-                    ref["summerBypassMinSupply"],
-                    ref["summerBypassPassiveCooling"],
-                    ref["demandindoorAirQuality"],
-                    ref["demandrelativeHumidity"],
-                ) = await asyncio.gather(
-                    limited_call(
-                        self.async_get_ventilation_exhaustfanlevel(device_id, zone_id)
-                    ),
-                    limited_call(
-                        self.async_get_ventilation_quality(device_id, zone_id)
-                    ),
-                    limited_call(
-                        self.async_get_ventilation_humidity(device_id, zone_id)
-                    ),
-                    limited_call(self.async_get_ventilation_mode(device_id, zone_id)),
-                    limited_call(
-                        self.async_get_ventilation_exhaust_temp(device_id, zone_id)
-                    ),
-                    limited_call(
-                        self.async_get_ventilation_extract_temp(device_id, zone_id)
-                    ),
-                    limited_call(
-                        self.async_get_ventilation_internal_quality(device_id, zone_id)
-                    ),
-                    limited_call(
-                        self.async_get_ventilation_internal_humidity(device_id, zone_id)
-                    ),
-                    limited_call(
-                        self.async_get_ventilation_outdoor_temp(device_id, zone_id)
-                    ),
-                    limited_call(
-                        self.async_get_ventilation_supply_temp(device_id, zone_id)
-                    ),
-                    limited_call(
-                        self.async_get_ventilation_summer_enable(device_id, zone_id)
-                    ),
-                    limited_call(
-                        self.async_get_ventilation_summer_duration(device_id, zone_id)
-                    ),
-                    limited_call(
-                        self.async_get_ventilation_summer_flap_power(device_id, zone_id)
-                    ),
-                    limited_call(
-                        self.async_get_ventilation_summer_min_supply(device_id, zone_id)
-                    ),
-                    limited_call(
-                        self.async_get_ventilation_summer_passive_cooling(
-                            device_id, zone_id
-                        )
-                    ),
-                    limited_call(
-                        self.async_get_ventilation_demand_quality(device_id, zone_id)
-                    ),
-                    limited_call(
-                        self.async_get_ventilation_demand_humidity(device_id, zone_id)
-                    ),
+                prefix = BOSCHCOM_ENDPOINT_VENTILATION + "/" + zone_id
+                vent_endpoints = [
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_FAN,
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_QUALITY,
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_HUMIDITY,
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_OPERATION_MODE,
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_EXHAUST_TEMP,
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_EXTRACT_TEMP,
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_INTERNAL_QUALITY,
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_INTERNAL_HUMIDITY,
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_OUTDOOR_TEMP,
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_SUPPLY_TEMP,
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_SUMMER_ENABLE,
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_SUMMER_DURATION,
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_SUMMER_FLAP_POWER,
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_SUMMER_MIN_SUPPLY,
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_SUMMER_PASSIVE_COOLING,
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_DEMAND_QUALITY,
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_DEMAND_HUMIDITY,
+                ]
+                vent_bulk = (
+                    await self.async_request_bulk(device_id, vent_endpoints) or {}
+                )
+                ref["exhaustFanLevel"] = vent_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_FAN
+                )
+                ref["maxIndoorAirQuality"] = vent_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_QUALITY
+                )
+                ref["maxRelativeHumidity"] = vent_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_HUMIDITY
+                )
+                ref["operationMode"] = vent_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_OPERATION_MODE
+                )
+                ref["exhaustTemp"] = vent_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_EXHAUST_TEMP
+                )
+                ref["extractTemp"] = vent_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_EXTRACT_TEMP
+                )
+                ref["internalAirQuality"] = vent_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_INTERNAL_QUALITY
+                )
+                ref["internalHumidity"] = vent_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_INTERNAL_HUMIDITY
+                )
+                ref["outdoorTemp"] = vent_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_OUTDOOR_TEMP
+                )
+                ref["supplyTemp"] = vent_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_SUPPLY_TEMP
+                )
+                ref["summerBypassEnable"] = vent_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_SUMMER_ENABLE
+                )
+                ref["summerBypassDuration"] = vent_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_SUMMER_DURATION
+                )
+                ref["summerBypassFlapPower"] = vent_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_SUMMER_FLAP_POWER
+                )
+                ref["summerBypassMinSupply"] = vent_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_SUMMER_MIN_SUPPLY
+                )
+                ref["summerBypassPassiveCooling"] = vent_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_SUMMER_PASSIVE_COOLING
+                )
+                ref["demandindoorAirQuality"] = vent_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_DEMAND_QUALITY
+                )
+                ref["demandrelativeHumidity"] = vent_bulk.get(
+                    prefix + BOSCHCOM_ENDPOINT_VENTILATION_DEMAND_HUMIDITY
                 )
 
             await asyncio.gather(*(populate_vent(ref) for ref in vent_refs))

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -124,7 +124,7 @@ def _k40_bulk_route(url, args, kwargs, overrides=None):  # noqa: ANN001, ANN202,
             return None
         if "outdoor_t1" in path:
             return None
-        if "ventilation" in path:
+        if path.endswith("/ventilation"):
             return {"references": []}
         if path.endswith("/zones"):
             return {"references": []}
@@ -136,7 +136,7 @@ def _k40_bulk_route(url, args, kwargs, overrides=None):  # noqa: ANN001, ANN202,
             return {"references": []}
         if "heatSources" in path:
             return None
-        return {}
+        return None
 
     return _mock_json_response(_build_bulk_response(resource_paths, _resolve))
 
@@ -1139,36 +1139,88 @@ async def test_k40_async_update_with_dhw_and_hc() -> None:  # noqa: C901, PLR091
     session = ClientSession()
     k40 = _make_k40(session)
 
-    async def route(method, url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202, ARG001, C901, PLR0911, PLR0912
+    async def route(method, url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202, ARG001, C901, PLR0911, PLR0915
         if "bulk" in url:
-            return _k40_bulk_route(
-                url,
-                args,
-                kwargs,
-                overrides={
-                    "/dhwCircuits": {"references": [{"id": "/dhwCircuits/dhw1"}]},
-                    "/heatingCircuits": {
-                        "references": [{"id": "/heatingCircuits/hc1"}]
-                    },
-                    "holidayMode": {"value": "off"},
-                    "awayMode": {"value": "off"},
-                    "powerLimitation": {"value": "off"},
-                    "outdoor_t1": {"value": 5.0},
-                    "indoor_h1": {"value": 43.5},
-                    "flameIndication": {"value": "ch"},
-                    "heatPumpType": {"value": "airToWater"},
-                    "numberOfStarts": {"value": 100},
-                    "returnTemperature": {"value": 30},
-                    "actualSupplyTemperature": {"value": 35},
-                    "actualModulation": {"value": 50},
-                    "collectorInflowTemp": {"value": 10},
-                    "collectorOutflowTemp": {"value": 8},
-                    "actualHeatDemand": {"value": 80},
-                    "workingTime": {"value": 5000},
-                    "totalConsumption": {"value": 1234},
-                    "systemPressure": {"value": 1.5},
-                },
-            )
+            posted_data = args[0] if args else kwargs.get("data", [{}])
+            resource_paths = posted_data[0].get("resourcePaths", [])
+
+            def _resolve(path):  # noqa: ANN001, ANN202, PLR0911, PLR0912, C901
+                if path.endswith("/dhwCircuits"):
+                    return {"references": [{"id": "/dhwCircuits/dhw1"}]}
+                if path.endswith("/heatingCircuits"):
+                    return {"references": [{"id": "/heatingCircuits/hc1"}]}
+                if "holidayMode" in path:
+                    return {"value": "off"}
+                if "awayMode" in path:
+                    return {"value": "off"}
+                if "powerLimitation" in path:
+                    return {"value": "off"}
+                if "outdoor_t1" in path:
+                    return {"value": 5.0}
+                if "indoor_h1" in path:
+                    return {"value": 43.5}
+                if "flameIndication" in path:
+                    return {"value": "ch"}
+                if "heatPumpType" in path:
+                    return {"value": "airToWater"}
+                if "numberOfStarts" in path:
+                    return {"value": 100}
+                if "returnTemperature" in path:
+                    return {"value": 30}
+                if "actualSupplyTemperature" in path:
+                    return {"value": 35}
+                if "actualModulation" in path:
+                    return {"value": 50}
+                if "collectorInflowTemp" in path:
+                    return {"value": 10}
+                if "collectorOutflowTemp" in path:
+                    return {"value": 8}
+                if "actualHeatDemand" in path:
+                    return {"value": 80}
+                if "workingTime" in path:
+                    return {"value": 5000}
+                if "totalConsumption" in path:
+                    return {"value": 1234}
+                if "systemPressure" in path:
+                    return {"value": 1.5}
+                # Per-HC endpoints
+                if "heatingCircuits" in path and "operationMode" in path:
+                    return {"value": "auto"}
+                if "heatingCircuits" in path and "currentSuWiMode" in path:
+                    return {"value": "summer"}
+                if "heatingCircuits" in path and "heatCoolMode" in path:
+                    return {"value": "heat"}
+                if "heatingCircuits" in path and "roomtemperature" in path:
+                    return {"value": 21.5}
+                if "heatingCircuits" in path and "actualHumidity" in path:
+                    return {"value": 55}
+                if "heatingCircuits" in path and "manualRoomSetpoint" in path:
+                    return {"value": 20}
+                if "heatingCircuits" in path and "currentRoomSetpoint" in path:
+                    return {"value": 21}
+                if "heatingCircuits" in path and "cooling/roomTempSetpoint" in path:
+                    return {"value": 25}
+                if "heatingCircuits" in path and "maxSupply" in path:
+                    return {"value": 90}
+                if "heatingCircuits" in path and "minSupply" in path:
+                    return {"value": 20}
+                if "heatingCircuits" in path and "heatCurveMax" in path:
+                    return {"value": 75}
+                if "heatingCircuits" in path and "heatCurveMin" in path:
+                    return {"value": 20}
+                if "heatingCircuits" in path and "supplyTemperatureSetpoint" in path:
+                    return {"value": 39}
+                if "heatingCircuits" in path and "nightSwitchMode" in path:
+                    return {"value": "off"}
+                if "heatingCircuits" in path and "control" in path:
+                    return {"value": "weather"}
+                if "heatingCircuits" in path and "nightThreshold" in path:
+                    return {"value": 21}
+                if "heatingCircuits" in path and "roomInfluence" in path:
+                    return {"value": 3}
+                return None
+
+            return _mock_json_response(_build_bulk_response(resource_paths, _resolve))
         if "dhwCircuits" in url and "operationMode" in url:
             return _mock_json_response({"value": "auto"})
         if "dhwCircuits" in url and "actualTemp" in url:
@@ -1192,40 +1244,6 @@ async def test_k40_async_update_with_dhw_and_hc() -> None:  # noqa: C901, PLR091
             and "Remaining" not in url
         ):
             return _mock_json_response({"value": "off"})
-        if "heatingCircuits" in url and "operationMode" in url:
-            return _mock_json_response({"value": "auto"})
-        if "heatingCircuits" in url and "currentSuWiMode" in url:
-            return _mock_json_response({"value": "summer"})
-        if "heatingCircuits" in url and "heatCoolMode" in url:
-            return _mock_json_response({"value": "heat"})
-        if "heatingCircuits" in url and "roomtemperature" in url:
-            return _mock_json_response({"value": 21.5})
-        if "heatingCircuits" in url and "actualHumidity" in url:
-            return _mock_json_response({"value": 55})
-        if "heatingCircuits" in url and "manualRoomSetpoint" in url:
-            return _mock_json_response({"value": 20})
-        if "heatingCircuits" in url and "currentRoomSetpoint" in url:
-            return _mock_json_response({"value": 21})
-        if "heatingCircuits" in url and "cooling/roomTempSetpoint" in url:
-            return _mock_json_response({"value": 25})
-        if "heatingCircuits" in url and "maxSupply" in url:
-            return _mock_json_response({"value": 90})
-        if "heatingCircuits" in url and "minSupply" in url:
-            return _mock_json_response({"value": 20})
-        if "heatingCircuits" in url and "heatCurveMax" in url:
-            return _mock_json_response({"value": 75})
-        if "heatingCircuits" in url and "heatCurveMin" in url:
-            return _mock_json_response({"value": 20})
-        if "heatingCircuits" in url and "supplyTemperatureSetpoint" in url:
-            return _mock_json_response({"value": 39})
-        if "heatingCircuits" in url and "nightSwitchMode" in url:
-            return _mock_json_response({"value": "off"})
-        if "heatingCircuits" in url and "control" in url:
-            return _mock_json_response({"value": "weather"})
-        if "heatingCircuits" in url and "nightThreshold" in url:
-            return _mock_json_response({"value": 21})
-        if "heatingCircuits" in url and "roomInfluence" in url:
-            return _mock_json_response({"value": 3})
         if "energy/historyEntries" in url:
             return _mock_json_response({"value": 1})
         if "energy/historyHourly" in url:
@@ -1316,18 +1334,20 @@ async def test_k40_async_update_with_ventilation() -> None:
 
     async def route(method, url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202, ARG001
         if "bulk" in url:
-            return _k40_bulk_route(
-                url,
-                args,
-                kwargs,
-                overrides={
-                    "ventilation": {"references": [{"id": "/ventilation/zone1"}]},
-                },
-            )
-        if "ventilation" in url:
-            for needle, payload in vent_substring_values.items():
-                if needle in url:
-                    return _mock_json_response(payload)
+            posted_data = args[0] if args else kwargs.get("data", [{}])
+            resource_paths = posted_data[0].get("resourcePaths", [])
+
+            def _resolve(path):  # noqa: ANN001, ANN202
+                if path.endswith("/ventilation"):
+                    return {"references": [{"id": "/ventilation/zone1"}]}
+                # Per-ventilation zone endpoints
+                if "ventilation" in path:
+                    for needle, payload in vent_substring_values.items():
+                        if needle in path:
+                            return payload
+                return None
+
+            return _mock_json_response(_build_bulk_response(resource_paths, _resolve))
         return _mock_json_response({})
 
     with patch.object(k40, "_async_http_request", new=AsyncMock(side_effect=route)):


### PR DESCRIPTION
Replaces individual GET requests in populate_hc (17 per heating circuit) and populate_vent (17 per ventilation zone) with single bulk POST calls via async_request_bulk.

This reduces HTTP round-trips significantly for systems with multiple heating circuits or ventilation zones while keeping the same data output.